### PR TITLE
Update debian packaging

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -66,6 +66,6 @@ distclean:
 	rm -rf ${DIR_LIST} config.h config.log config.status
 
 install: all
-	@mkdir -p $(INSTALL_BIN)
-	$(INSTALL) telegram $(INSTALL_BIN)
+	@mkdir -p $(DESTDIR)/$(INSTALL_BIN)
+	$(INSTALL) bin/telegram-cli $(DESTDIR)/$(INSTALL_BIN)
 	rm -rf ${DIR_LIST} config.log config.status > /dev/null || echo "all clean"

--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,7 @@ Build-Depends: autoconf-archive,
                libjansson-dev,
                libpython-dev,
                liblua5.2-dev,
+               libgcrypt-dev,
                lua-lgi,
                lua5.2
 Standards-Version: 3.9.5

--- a/debian/install
+++ b/debian/install
@@ -1,4 +1,4 @@
-bin/telegram-cli usr/bin
+#bin/telegram-cli usr/bin
 server.pub etc/telegram-cli
 
 #bin/telegram-cli usr/share/telegram-daemon/bin

--- a/debian/rules
+++ b/debian/rules
@@ -11,8 +11,13 @@ export DH_VERBOSE=1
 
 	VERSION=$(shell dpkg-parsechangelog | sed -n 's/^Version: //p' | cut -f1 -d'-')
 	PACKAGE_NAME=$(shell dpkg-parsechangelog | sed -n 's/^Source: //p')
+
 override_dh_auto_configure:
 	./configure --disable-openssl --prefix=/usr
+
+override_dh_usrlocal:
+	
+
 %:
 			cp tg-server.pub server.pub
 			dh $@ --with autotools-dev

--- a/debian/rules
+++ b/debian/rules
@@ -12,7 +12,7 @@ export DH_VERBOSE=1
 	VERSION=$(shell dpkg-parsechangelog | sed -n 's/^Version: //p' | cut -f1 -d'-')
 	PACKAGE_NAME=$(shell dpkg-parsechangelog | sed -n 's/^Source: //p')
 override_dh_auto_configure:
-	./configure --disable-openssl
+	./configure --disable-openssl --prefix=/usr
 %:
 			cp tg-server.pub server.pub
 			dh $@ --with autotools-dev


### PR DESCRIPTION
This PR fixes the debian build with 4 commits;

    debian/rules: prevent run of dh_usrlocal
    fix install step (telegram -> bin/telegram-cli)
    debian/rules: configure using prefix=/usr
    debian/control: add missing dependency libgcrypt-dev
