### PR TITLE
tg: fix build on gcc-10 (-fno-common)

### DIFF
--- a/interface.c
+++ b/interface.c
@@ -132,7 +132,7 @@ int do_html;
 int safe_quit;
 
 int in_readline;
-int readline_active;
+static int readline_active;
 
 int log_level;
 
@@ -3759,7 +3759,6 @@ void interpreter (char *line) {
   interpreter_ex (line, 0);
 }
 
-int readline_active;
 /*void rprintf (const char *format, ...) {
   mprint_start (ev);
   va_list ap;

--- a/loop.c
+++ b/loop.c
@@ -87,7 +87,6 @@ extern int binlog_enabled;
 
 extern int unknown_user_list_pos;
 extern int unknown_user_list[];
-int register_mode;
 extern int safe_quit;
 extern int sync_from_start;
 
@@ -387,7 +386,6 @@ int all_authorized (void) {
 int zero[512];
 
 
-int readline_active;
 int new_dc_num;
 int wait_dialog_list;
 

--- a/main.c
+++ b/main.c
@@ -90,8 +90,8 @@
   "# Feel free to put something here\n"
 
 int bot_mode;
-int verbosity;
-int msg_num_mode;
+extern int verbosity;
+extern int msg_num_mode;
 char *default_username;
 char *config_filename;
 char *prefix;
@@ -108,7 +108,7 @@ int binlog_enabled;
 extern int log_level;
 int sync_from_start;
 int allow_weak_random;
-int disable_colors;
+extern int disable_colors;
 int readline_disabled;
 int disable_output;
 int reset_authorization;
@@ -121,8 +121,8 @@ int enable_json;
 int alert_sound;
 int auto_mark_read;
 int exit_code;
-int permanent_msg_id_mode;
-int permanent_peer_id_mode;
+extern int permanent_msg_id_mode;
+extern int permanent_peer_id_mode;
 char *home_directory;
 
 struct tgl_state *TLS;
@@ -517,9 +517,8 @@ void usage (void) {
 char *log_net_file;
 FILE *log_net_f;
 
-int register_mode;
-int disable_auto_accept;
-int wait_dialog_list;
+extern int disable_auto_accept;
+extern int wait_dialog_list;
 
 char *logname;
 int daemonize=0;


### PR DESCRIPTION
gcc-10 changed the default from -fcommon to fno-common:
  https://gcc.gnu.org/PR85678

As a result build fails as:

    ld: objs/loop.o:/build/tg/loop.c:77: multiple definition of
      `verbosity'; objs/main.o:/build/tg/main.c:93: first defined here